### PR TITLE
Fix to missing runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "MIT"
   ],
   "dependencies": {
-    "fibers": ">=0.6.7"
+    "fibers": ">=0.6.7",
+    "coffee-script": "*"
   },
   "devDependencies": {
-    "jasmine-node": "1.8.x",
-    "coffee-script": "*"
+    "jasmine-node": "1.8.x"
   },
   "main": "lib/fibrous",
   "bin": {


### PR DESCRIPTION
Found issue.  Uninstalled fibrous and coffee-script.  Cloned repo, moved dependency from devDependencies to dependencies.  Reran failure conditions (e.g. npm install -g fibrous from local, no coffee-script installed).  Observed coffeescript installed this time.  Fibrous repl worked as expected, no bug.
