### PR TITLE
[issue #20] Pass error to middleware chain

### DIFF
--- a/lib/fibrous.js
+++ b/lib/fibrous.js
@@ -167,7 +167,8 @@
           return next();
         } catch (_error) {
           e = _error;
-          return console.error('Unexpected error bubble up to the top of the fiber:', (e != null ? e.stack : void 0) || e);
+          console.error('Unexpected error bubbled up to the top of the fiber:', (e != null ? e.stack : void 0) || e);
+          return next(new Error((e != null ? e.message : void 0) || e));
         }
       }).run();
     });

--- a/spec/fibrous.spec.coffee
+++ b/spec/fibrous.spec.coffee
@@ -174,6 +174,17 @@ describe 'fibrous', ->
         expect(Fiber.current).toBeTruthy()
         done()
 
+    it 'passes error through middleware chain', (done) ->
+      spyOn(console, 'error')
+      next = (err) ->
+        if err?
+          expect(err.message).toBe 'Thrown Error'
+          expect(console.error).toHaveBeenCalled()
+          done()
+        else
+          throw new Error 'Thrown Error'
+      fibrous.middleware {}, {}, next
+
   describe 'Future', ->
     it "exports node-fibers Future", ->
       expect(fibrous.Future).toEqual Future

--- a/src/fibrous.coffee
+++ b/src/fibrous.coffee
@@ -121,8 +121,9 @@ fibrous.middleware = (req, res, next) ->
       try
         next()
       catch e
-        # We expect any errors which bubble up the fiber will be handled by the router
-        console.error('Unexpected error bubble up to the top of the fiber:', e?.stack or e)
+        console.error('Unexpected error bubbled up to the top of the fiber:', e?.stack or e)
+        # Pass error to the middleware chain
+        next(new Error(e?.message or e))
     .run()
 
 # Create a new fibrous function and run it. Handle errors with try/catch or pass an error


### PR DESCRIPTION
Resolves issue #20.

@randypuro the comment in this code seemed to imply that we didn't want to explicitly pass the error along to be handled by the middleware chain. I was seeing that an error thrown in a route handler was being logged to console.error but the response was never completing. Does this implementation look problematic to you for any reason?
