### PR TITLE
Ensure that fibrous is initialized at most once per process

### DIFF
--- a/lib/fibrous.js
+++ b/lib/fibrous.js
@@ -3,13 +3,18 @@
   var Fiber, Future, base, defineMemoizedPerInstanceProperty, fibrous, functionWithFiberReturningFuture, futureize, proxyAll, proxyBuilder, synchronize, _i, _len, _ref,
     __slice = [].slice;
 
+  if (process.fibrous != null) {
+    module.exports = process.fibrous;
+    return;
+  }
+
   Fiber = require('fibers');
 
   Future = require('fibers/future');
 
   functionWithFiberReturningFuture = Function.prototype.future;
 
-  module.exports = fibrous = function(fn) {
+  module.exports = process.fibrous = fibrous = function(fn) {
     var asyncFn, futureFn;
     futureFn = functionWithFiberReturningFuture.call(fn);
     asyncFn = function(cb) {

--- a/spec/fibrous.spec.coffee
+++ b/spec/fibrous.spec.coffee
@@ -165,7 +165,7 @@ describe 'fibrous', ->
       , (err) ->
         expect(err).toEqual(new Error('async error'))
         done()
-     
+
   describe 'middleware', ->
 
     it 'runs in a fiber', (done) ->
@@ -186,6 +186,16 @@ describe 'fibrous', ->
 
     it "does not crash when trying to access sync or future", ->
       expect( -> obj.sync ).not.toThrow()
+
+  describe 'initialization', ->
+    it 'does not throw an error when required multiple times', ->
+      fibrousPath = require.resolve '../lib/fibrous'
+      expect(require.cache[fibrousPath]).toBeDefined()
+      delete require.cache[fibrousPath]
+
+      expect ->
+        fibrous = require '../lib/fibrous'
+      .not.toThrow()
 
   describe 'inheritance', ->
 

--- a/src/fibrous.coffee
+++ b/src/fibrous.coffee
@@ -1,3 +1,8 @@
+# Initialize fibrous exactly once since its initialization is not idempotent
+if process.fibrous?
+  module.exports = process.fibrous
+  return
+
 Fiber = require 'fibers'
 Future = require 'fibers/future'
 
@@ -5,7 +10,7 @@ Future = require 'fibers/future'
 # Keep a reference so we can use theirs later.
 functionWithFiberReturningFuture = Function::future
 
-module.exports = fibrous = (fn) ->
+module.exports = process.fibrous = fibrous = (fn) ->
   futureFn = functionWithFiberReturningFuture.call(fn) # handles all the heavy lifting of inheriting an existing fiber when appropriate
   # Don't use (args...) here because asyncFn.length == 0 when we do.
   # A common (albeit short-sighted) pattern used in node.js code is checking


### PR DESCRIPTION
Currently two packages cannot independently depend on fibrous without causing a
crash. When the second copy of fibrous is initialized, it tries to redefine
`Object/Function::sync/future`, which throws an error since the first copy of
fibrous defined those properties to be non-configurable. But even if they were
to be configurable, the second copy of fibrous would not be able to get a
reference to node-fiber's `Function::future` (because the first copy of fibrous
overrides it).

This diff's approach is similar to node-fiber's guard against double-inclusion,
which uses the `process` object to ensure the module is initialized at most
once.

Test case is included. Fixes #31.
